### PR TITLE
fix: esp32 wrover firmware small in github due to silence mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
         pip install --upgrade pip
         pip install pyyaml xlrd
         mkdir build
-        echo -e "{\"platform\": \"PLATFORM_ESP32\", \"module\": \"WROVER-32\", \"silence\": 1}" > build/module_info.json
+        echo -e "{\"platform\": \"PLATFORM_ESP32\", \"module\": \"WROVER-32\", \"silence\": 0}" > build/module_info.json
         ./build.py reconfigure || echo "skip exception"
       shell: bash
     - name: Install dependencies


### PR DESCRIPTION
esp32 wrover firmware small in github due to silence mode